### PR TITLE
Implement _send_transaction for smart contracts.

### DIFF
--- a/src/components/contract/ContractStore.tsx
+++ b/src/components/contract/ContractStore.tsx
@@ -114,7 +114,22 @@ export default class ContractStore {
                 abort: () => {
                     console.log("abort called");
                 },
-                // todo: add send_transaction
+                _send_transaction: (
+                    tag: any,
+                    payloadPointer: any,
+                    payloadLen: number
+                ) => {
+                    const sendTxView = new Uint8Array(
+                        memory.buffer,
+                        payloadPointer,
+                        payloadLen
+                    );
+                    const sendTxpayload = decoder.decode(sendTxView);
+
+                    const sendTxMsg = `Sent transaction with tag ${tag} and payload ${sendTxpayload}.`;
+                    console.log(sendTxMsg);
+                    this.logs.push(sendTxMsg);
+                },
                 _payload_len: () => {
                     return contractPayload.length;
                 },


### PR DESCRIPTION
**Problem**
send_transaction() is missing on imports object for local Webassembly simulate calls, the issue should not affecting anything, the smart contract in the network would be called eventually whether it has an error or not.
