### PR TITLE
Allow custom protocols for api host and web socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "file-loader": "0.11.2",
         "fork-ts-checker-webpack-plugin": "^0.5.2",
         "fs-extra": "3.0.1",
+        "gh-pages": "^2.1.1",
         "html-webpack-plugin": "2.29.0",
         "jest": "22.4.2",
         "jsbi": "^2.0.5",
@@ -99,9 +100,9 @@
     },
     "scripts": {
         "start": "node scripts/start.js",
-        "start-secure": "REACT_APP_HTTPS=true node scripts/start.js",
         "build": "GENERATE_SOURCEMAP=false node scripts/build.js",
-        "build-secure": "GENERATE_SOURCEMAP=false REACT_APP_HTTPS=true node scripts/build.js",
+        "deploy": "PUBLIC_URL=/lens REACT_APP_DEFAULT_API_HOST=https://testnet.perlin.net npm run build && npm run gh-pages",
+        "gh-pages": "gh-pages -d build -b gh-pages",
         "test": "node scripts/test.js --env=jsdom",
         "lint:prettier": "prettier --write src/**/*.{js,jsx,ts,tsx}"
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "scripts": {
         "start": "node scripts/start.js",
         "build": "GENERATE_SOURCEMAP=false node scripts/build.js",
-        "deploy": "PUBLIC_URL=/lens REACT_APP_DEFAULT_API_HOST=https://testnet.perlin.net npm run build && npm run gh-pages",
+        "deploy:subfolder": "PUBLIC_URL=/lens npm run deploy",
+        "deploy": "REACT_APP_DEFAULT_API_HOST=https://testnet.perlin.net npm run build && npm run gh-pages",
         "gh-pages": "gh-pages -d build -b gh-pages",
         "test": "node scripts/test.js --env=jsdom",
         "lint:prettier": "prettier --write src/**/*.{js,jsx,ts,tsx}"

--- a/src/Perlin.tsx
+++ b/src/Perlin.tsx
@@ -3,7 +3,7 @@ import * as storage from "./storage";
 import * as nacl from "tweetnacl";
 import * as _ from "lodash";
 import { ITransaction, Tag } from "./types/Transaction";
-import { HTTP_PROTOCOL, WS_PROTOCOL, FAUCET_URL } from "./constants";
+import { FAUCET_URL } from "./constants";
 import { SmartBuffer } from "smart-buffer";
 import PayloadReader from "./payload/PayloadReader";
 import { IAccount } from "./types/Account";
@@ -80,6 +80,7 @@ class Perlin {
 
     @observable public api = {
         host: storage.getCurrentHost(),
+        ws: storage.getCurrentHost().replace(/^http/, "ws"),
         token: ""
     };
 
@@ -148,7 +149,7 @@ class Perlin {
         if (secret) {
             this.login(secret);
         }
-        this.client = new Wavelet(`${HTTP_PROTOCOL}://${this.api.host}`);
+        this.client = new Wavelet(this.api.host);
     }
 
     @action.bound
@@ -339,7 +340,7 @@ class Perlin {
         params?: any,
         headers?: any
     ): Promise<Response> {
-        const url = new URL(`${HTTP_PROTOCOL}://${this.api.host}${endpoint}`);
+        const url = new URL(`${this.api.host}${endpoint}`);
         Object.keys(params).forEach(key =>
             url.searchParams.append(key, params[key])
         );
@@ -393,16 +394,13 @@ class Perlin {
         body?: any,
         headers?: any
     ): Promise<any> {
-        const response = await fetch(
-            `${HTTP_PROTOCOL}://${this.api.host}${endpoint}`,
-            {
-                method: "post",
-                headers: {
-                    ...headers
-                },
-                body: JSON.stringify(body)
-            }
-        );
+        const response = await fetch(`${this.api.host}${endpoint}`, {
+            method: "post",
+            headers: {
+                ...headers
+            },
+            body: JSON.stringify(body)
+        });
 
         return await response.json();
     }
@@ -494,7 +492,7 @@ class Perlin {
     }
 
     private pollMetricsUpdates() {
-        const url = new URL(`${WS_PROTOCOL}://${this.api.host}/poll/metrics`);
+        const url = new URL(`${this.api.ws}/poll/metrics`);
 
         const ws = new ReconnectingWebSocket(url.toString());
 

--- a/src/components/login/LoginContainer.tsx
+++ b/src/components/login/LoginContainer.tsx
@@ -161,7 +161,7 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
     const handleChange = useCallback((e: any) => {
         setSecretKey(e.target.value);
     }, []);
-    const currentHost = getCurrentHost();
+    const [host, setHost] = useState(getCurrentHost());
 
     useEffect(() => {
         generateNewKeys();
@@ -215,6 +215,9 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
     }, [secretKey]);
 
     const login = async () => {
+        const newHost = /^http/.test(host) ? host : "http://" + host;
+        setCurrentHost(newHost);
+
         if (!secretKey) {
             errorNotification("Please enter a Private key");
             return;
@@ -239,7 +242,7 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
     };
 
     const apiHostChangeHandler = useCallback((event: any) => {
-        setCurrentHost(event.target.value);
+        setHost(event.target.value);
     }, []);
 
     if (perlin.isLoggedIn) {
@@ -300,7 +303,7 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
                         <Box mb={4}>
                             <label>API Address</label>
                             <LargeInput
-                                defaultValue={currentHost}
+                                defaultValue={host}
                                 onChange={apiHostChangeHandler}
                             />
                         </Box>

--- a/src/components/login/LoginContainer.tsx
+++ b/src/components/login/LoginContainer.tsx
@@ -161,7 +161,7 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
     const handleChange = useCallback((e: any) => {
         setSecretKey(e.target.value);
     }, []);
-    const [host, setHost] = useState(getCurrentHost());
+    const currentHost = getCurrentHost();
 
     useEffect(() => {
         generateNewKeys();
@@ -215,9 +215,6 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
     }, [secretKey]);
 
     const login = async () => {
-        const newHost = /^http/.test(host) ? host : "http://" + host;
-        setCurrentHost(newHost);
-
         if (!secretKey) {
             errorNotification("Please enter a Private key");
             return;
@@ -242,7 +239,7 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
     };
 
     const apiHostChangeHandler = useCallback((event: any) => {
-        setHost(event.target.value);
+        setCurrentHost(event.target.value);
     }, []);
 
     if (perlin.isLoggedIn) {
@@ -303,7 +300,7 @@ const LoginContainer: React.FunctionComponent<RouteComponentProps> = ({
                         <Box mb={4}>
                             <label>API Address</label>
                             <LargeInput
-                                defaultValue={host}
+                                defaultValue={currentHost}
                                 onChange={apiHostChangeHandler}
                             />
                         </Box>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,10 +5,9 @@ export const STORAGE_KEYS = {
     NETWORK_GRAPH_NODES_LIMIT: "networkGraphNodeLimit",
     SECRET_KEY: "secretKey"
 };
-export const DEFAULT_API_HOST = location.hostname + ":9000";
-export const HTTPS = !!process.env.REACT_APP_HTTPS;
-export const HTTP_PROTOCOL = HTTPS ? "https" : "http";
-export const WS_PROTOCOL = HTTPS ? "wss" : "ws";
+export const DEFAULT_API_HOST =
+    process.env.REACT_APP_DEFAULT_API_HOST ||
+    `${location.protocol}//${location.hostname}:9000`;
 export const DEFAULT_TRANSACTION_GRAPH_NODES_LIMIT = 500;
 export const TX_FEE = 2;
 export const DEFAULT_NETWORK_GRAPH_NODES_LIMIT = 500;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const STORAGE_KEYS = {
     STORED_HOSTS: "storedHosts",
-    CURRENT_HOST: "currentHost",
+    CURRENT_HOST: "host",
     TRANSACTION_GRAPH_NODES_LIMIT: "transactionGraphNodeLimit",
     NETWORK_GRAPH_NODES_LIMIT: "networkGraphNodeLimit",
     SECRET_KEY: "secretKey"

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -47,10 +47,12 @@ const getSecretKey = (): string | undefined => {
 };
 
 const setCurrentHost = (host: string) => {
-    store.set(STORAGE_KEYS.CURRENT_HOST, host);
+    const newHost = /^http/.test(host) ? host : "http://" + host;
+
+    store.set(STORAGE_KEYS.CURRENT_HOST, newHost);
     const storedHosts = getStoredHosts();
-    if (storedHosts.indexOf(host) === -1) {
-        setStoredHosts(storedHosts.concat(host));
+    if (storedHosts.indexOf(newHost) === -1) {
+        setStoredHosts(storedHosts.concat(newHost));
     }
 };
 
@@ -60,11 +62,15 @@ const removeSecretKey = () => {
 
 const getCurrentHost = (): string => {
     const currentHost = store.get(STORAGE_KEYS.CURRENT_HOST);
+
     if (!currentHost) {
         setCurrentHost(DEFAULT_API_HOST);
         return DEFAULT_API_HOST;
     }
-    return currentHost;
+    const newHost = /^http/.test(currentHost)
+        ? currentHost
+        : "http://" + currentHost;
+    return newHost;
 };
 
 const watchCurrentHost = (cb: (newHost: string) => void) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,7 +1152,7 @@ async@^1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.1.2, async@^2.1.4, async@^2.4.1, async@^2.5.0:
+async@^2.1.2, async@^2.1.4, async@^2.4.1, async@^2.5.0, async@^2.6.1:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -2724,7 +2724,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.12.1, commander@^2.14.1, commander@^2.9.0, commander@~2.20.0:
+commander@2, commander@^2.12.1, commander@^2.14.1, commander@^2.18.0, commander@^2.9.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -3868,6 +3868,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+email-addresses@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.0.3.tgz#fc3c6952f68da24239914e982c8a7783bc2ed96d"
+  integrity sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==
+
 emitter-component@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
@@ -4420,6 +4425,28 @@ filename-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
   integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
 
+filename-reserved-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz#e61cf805f0de1c984567d0386dc5df50ee5af7e4"
+  integrity sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=
+
+filenamify-url@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/filenamify-url/-/filenamify-url-1.0.0.tgz#b32bd81319ef5863b73078bed50f46a4f7975f50"
+  integrity sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=
+  dependencies:
+    filenamify "^1.0.0"
+    humanize-url "^1.0.0"
+
+filenamify@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-1.2.1.tgz#a9f2ffd11c503bed300015029272378f1f1365a5"
+  integrity sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=
+  dependencies:
+    filename-reserved-regex "^1.0.0"
+    strip-outer "^1.0.0"
+    trim-repeated "^1.0.0"
+
 fileset@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
@@ -4670,6 +4697,15 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
@@ -4801,6 +4837,20 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+gh-pages@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-2.1.1.tgz#5be70a92f9cb70404bafabd8bb149c0e9a8c264b"
+  integrity sha512-yNW2SFp9xGRP/8Sk2WXuLI/Gn92oOL4HBgudn6PsqAnuWT90Y1tozJoTfX1WdrDSW5Rb90kLVOf5mm9KJ/2fDw==
+  dependencies:
+    async "^2.6.1"
+    commander "^2.18.0"
+    email-addresses "^3.0.1"
+    filenamify-url "^1.0.0"
+    fs-extra "^7.0.0"
+    globby "^6.1.0"
+    graceful-fs "^4.1.11"
+    rimraf "^2.6.2"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -5344,6 +5394,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+humanize-url@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/humanize-url/-/humanize-url-1.0.1.tgz#f4ab99e0d288174ca4e1e50407c55fbae464efff"
+  integrity sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=
+  dependencies:
+    normalize-url "^1.0.0"
+    strip-url-auth "^1.0.0"
 
 husky@^1.3.1:
   version "1.3.1"
@@ -7467,7 +7525,7 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize-url@^1.4.0:
+normalize-url@^1.0.0, normalize-url@^1.4.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
   integrity sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=
@@ -10168,6 +10226,18 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strip-outer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
+strip-url-auth@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
+  integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
+
 style-loader@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.19.0.tgz#7258e788f0fee6a42d710eaf7d6c2412a4c50759"
@@ -10572,6 +10642,13 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- API host fields should now include the protocol.
- Web socket will use the API host and corresponding protocol.
- simplified deployment to github pages by just running `npm run deploy`