### PR TITLE
Fixes contract upload not working in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "react-dev-utils": "^5.0.1",
         "react-dom": "16.8.3",
         "react-dropdown": "^1.6.4",
-        "react-dropzone": "^10.0.0",
+        "react-dropzone": "^10.1.8",
         "react-infinite-scroller": "^1.2.4",
         "react-notifications-component": "^1.1.1",
         "react-qr-code": "^0.1.3",

--- a/src/components/contract/ContractUploader.tsx
+++ b/src/components/contract/ContractUploader.tsx
@@ -353,7 +353,7 @@ const ContractUploader: React.FunctionComponent = () => {
     );
 
     const { getRootProps, getInputProps, isDragActive } = useDropzone({
-        accept: "application/wasm",
+        accept: ["application/wasm", ""], // added "application/wasm is not supported by Safari"
         onDropAccepted,
         multiple: false
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8793,10 +8793,10 @@ react-dropdown@^1.6.4:
   dependencies:
     classnames "^2.2.3"
 
-react-dropzone@^10.0.0:
-  version "10.1.7"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.1.7.tgz#faba6b460a41a27a2d642316602924fe0ec2139c"
-  integrity sha512-PT4DHJCQrY/2vVljupveqnlwzVRQGK7U6mhoO0ox6kSJV0EK6W1ZmZpRyHMA1S6/KUOzN+1pASUMSqV/4uAIXg==
+react-dropzone@^10.1.8:
+  version "10.1.8"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.1.8.tgz#348895a3ee9efe7c0f6a2f19642f04704c170757"
+  integrity sha512-Lm6+TxIDf/my4i3VdYmufRcrJ4SUbSTJP3HB49V2+HNjZwLI4NKVkaNRHwwSm9CEuzMP+6SW7pT1txc1uBPfDg==
   dependencies:
     attr-accept "^1.1.3"
     file-selector "^0.1.11"


### PR DESCRIPTION
React-dropzone was restricted to application/wasm MIME which Safari  (<=12) doesn't support yet.
Added empty "" as accepted file type so upload works.